### PR TITLE
install bee using install.sh

### DIFF
--- a/content/bee-docs/installation/index.md
+++ b/content/bee-docs/installation/index.md
@@ -12,14 +12,15 @@ The client can be installed on MacOS and various Linux flavors.
 ## Installing the Bee binary
 At every official release, we release the binary files of our software. You can download them by navigating to [releases](https://github.com/ethersphere/bee/releases).
 
-A convenient way to download the binary is:
+A convenient way to download the binary is using `install.sh` script:
 
-```sh
-wget https://github.com/ethersphere/bee/releases/latest/download/bee-darwin-amd64 -O /usr/local/bin/bee
-chmod +x /usr/local/bin/bee
-```
+Grab the latest release:
+- wget: `wget -q -O - https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | bash`
+- curl: `curl -s https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | bash`
 
-Please change the last part of the url (`bee-darwin-amd64`), if you are not on a `darwin-amd64` system. A list of supported systems is available at [releases](https://github.com/ethersphere/bee/releases).
+Grab a specific release (via TAG environment variable):
+- wget: `wget -q -O - https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | TAG=v0.1.0 bash`
+- curl: `curl -s https://raw.githubusercontent.com/ethersphere/bee/master/install.sh | TAG=v0.1.0 bash`
 
 ## Installing Bee with Docker
 Bee can be run as a docker container.


### PR DESCRIPTION
`install.sh` just got [merged](https://github.com/ethersphere/bee/pull/468) into bee master, this script will detect OS and ARCH and install/upgrade bee binary to proper location