### PR TITLE
Fix typos on  install/docker.md documentation

### DIFF
--- a/docs/installation/build-from-source.md
+++ b/docs/installation/build-from-source.md
@@ -41,7 +41,7 @@ make binary
 5) Check you are able to run the `bee` command. Success can be verified by running:
 ```sh
 dist/bee version
-> 0.3.0
+> 0.3.1
 ```
 
 6) (optional) Additionally, you may also like to move the Bee binary to somewhere in your `$PATH`

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -26,7 +26,7 @@ docker run\
 If starting your node for the first time, you will need to deploy a chequebook contract. See [Start Your Node](/docs/getting-started/start-your-node) for more info.
 :::
 
-To persist files mount a local directory as follows and enter the password used to encrypt your keyfiles. Note, Docker insists on absolute paths when mounting volumes, so you must replace `/path/to/.bee-docker` with a valid path from your local filesystem.
+To persist files, mount a local directory as follows and enter the password used to encrypt your keyfiles. Note, Docker insists on absolute paths when mounting volumes, so you must replace `/path/to/.bee-docker` with a valid path from your local filesystem.
 
 ```sh
 docker run\
@@ -59,7 +59,7 @@ docker run\
 
 ### Versions
 
-You other versions of the Bee container are also available.
+Other versions of the Bee container are also available.
 
 #### Latest beta Release
 


### PR DESCRIPTION
This fixes a couple typos in the install/docker.md documentation.