### PR TITLE
Add network-id to command line options in example

### DIFF
--- a/docs/getting-started/start-your-node.md
+++ b/docs/getting-started/start-your-node.md
@@ -45,7 +45,8 @@ To find out your Ethereum address, we can simply run our Bee node and point it a
 bee start \
   --verbosity 5 \
   --swap-endpoint https://rpc.slock.it/goerli \
-  --debug-api-enable
+  --debug-api-enable \
+  --network-id 2 \
   --bootnode /dnsaddr/bootnode.staging.ethswarm.org
 ```
 


### PR DESCRIPTION
The default network-id on the public network is 2. If you start your node without specifying it there will be a lot of errors when peers connect. This PR adds the network-id to the documentation.