### PR TITLE
add default.nix file

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+# This is a descriptor for the Nix package manager.
+# Invoke nix-shell in this directory to enter an environment where
+# everything gets downloaded and made available for development.
+
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "bee-docs";
+
+  buildInputs = [
+    coreutils diffutils
+    bash-completion less
+    gitFull
+    nodejs
+  ];
+
+  buildCommand = ''
+    npm run build
+  '';
+
+  shellHook =
+  ''
+    npm start
+  '';
+}


### PR DESCRIPTION
whoever is using `nixos`, or has the nix package manager installed,
can immediately start development by simply typing `nix-shell` in this
directory. all the dependencies get automatically downloaded and made
available in the current shell, and even `npm start` is issued, and the
page is opened in the browser.

this greatly lowers the barrier to potential contributors.