### PR TITLE
fix typo in Clef installation

### DIFF
--- a/docs/installation/bee-clef.md
+++ b/docs/installation/bee-clef.md
@@ -21,7 +21,7 @@ Bee clef can be installed automatically using your system's package manager.
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_amd64.deb
-sudo dpkg -i bee-clef_0.4.4_amd64.deb
+sudo dpkg -i bee-clef_0.4.2_amd64.deb
 ```
 
 #### ARM (Raspberry Pi)
@@ -30,14 +30,14 @@ sudo dpkg -i bee-clef_0.4.4_amd64.deb
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_armv7.deb
-sudo dpkg -i bee-clef_0.4.4_armv7.deb
+sudo dpkg -i bee-clef_0.4.2_armv7.deb
 ```
 
 ##### ARM64
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_arm64.deb
-sudo dpkg -i bee-clef_0.4.4_arm64.deb
+sudo dpkg -i bee-clef_0.4.2_arm64.deb
 ```
 
 ### CentOS
@@ -46,7 +46,7 @@ sudo dpkg -i bee-clef_0.4.4_arm64.deb
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_amd64.rpm
-sudo rpm -i bee-clef_0.4.4_amd64.rpm
+sudo rpm -i bee-clef_0.4.2_amd64.rpm
 ```
 
 #### ARM (Raspberry Pi)
@@ -55,14 +55,14 @@ sudo rpm -i bee-clef_0.4.4_amd64.rpm
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_armv7.rpm
-sudo rpm -i bee-clef_0.4.4_armv7.rpm
+sudo rpm -i bee-clef_0.4.2_armv7.rpm
 ```
 
 ##### ARM64
 
 ```sh
 wget https://github.com/ethersphere/bee-clef/releases/download/v0.4.2/bee-clef_0.4.2_arm64.rpm
-sudo rpm -i bee-clef_0.4.4_arm64.rpm
+sudo rpm -i bee-clef_0.4.2_arm64.rpm
 ```
 
 ### MacOS


### PR DESCRIPTION
in the Clef installation the *nix instructions have `wget` fetching version `0.4.2` of Clef, but then using `dpkg` (or similar) to install `0.4.4`. Upon research `0.4.2` appears to be the correct latest version, so the `dpkg` and similar have been updated to reflect this value.

Cheers!