### PR TITLE
Update 'Book of Swarm' link to new swarm gateway

### DIFF
--- a/docs/advanced/swap.md
+++ b/docs/advanced/swap.md
@@ -14,7 +14,7 @@ earn some gBZZ!
 
 :::info
 Learn more about how SWAP and the other accounting protocols work by reading
-[The Book of Swarm](https://swarm-gateways.net/bzz:/latest.bookofswarm.eth/the-book-of-swarm.pdf).
+[The Book of Swarm](https://gateway.ethswarm.org/bzz/latest.bookofswarm.eth/).
 :::
 
 


### PR DESCRIPTION
Book of Swarm link was facing the old swarm gateway & this PR is to replace with new link